### PR TITLE
Move debug formatting to where it is used

### DIFF
--- a/driver/support_library/include/ethosn_support_library/Support.hpp
+++ b/driver/support_library/include/ethosn_support_library/Support.hpp
@@ -1,5 +1,6 @@
 //
 // Copyright © 2018-2024 Arm Limited.
+// Copyright © 2024 Axis Communications AB.
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -25,7 +26,7 @@
 // Version information
 #define ETHOSN_SUPPORT_LIBRARY_VERSION_MAJOR 5
 #define ETHOSN_SUPPORT_LIBRARY_VERSION_MINOR 0
-#define ETHOSN_SUPPORT_LIBRARY_VERSION_PATCH 0
+#define ETHOSN_SUPPORT_LIBRARY_VERSION_PATCH 1
 
 namespace ethosn
 {
@@ -249,6 +250,36 @@ struct PassStats
     MceStats m_Mce;
     PleStats m_Ple;
 };
+
+// Some extra stats only used for debug
+struct PassDebugStats
+{
+    bool valid;
+    uint32_t numInputStripes;
+    double inputBytes;
+    double inputCycles;
+    double inputParallelCycles;
+    double inputNonParallelCycles;
+    uint32_t numWeightStripes;
+    double weightBytes;
+    double weightCycles;
+    double weightParallelCycles;
+    double weightNonParallelCycles;
+    double dmaReadParallelCycles;
+    double dmaReadNonParallelCycles;
+    uint32_t numOutputStripes;
+    double outputBytes;
+    double outputCycles;
+    double outputParallelCycles;
+    double outputNonParallelCycles;
+    double dmaWriteParallelCycles;
+    double dmaWriteNonParallelCycles;
+    double mceCycles;
+    uint32_t numMceStripes;
+    double pleCycles;
+    uint32_t numPleStripes;
+};
+
 
 /// Performance data for a single pass pairs performance stats with network topology meta-data.
 struct PassPerformanceData

--- a/driver/support_library/src/Estimation.cpp
+++ b/driver/support_library/src/Estimation.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright © 2018-2023 Arm Limited.
+// Copyright © 2024 Axis Communications AB.
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -136,7 +137,7 @@ EstimatedPass EstimateConversionPassGrownFrom(const OpGraph& opGraph,
     passDesc.m_OutputDma  = secondDmaOp;
     passDesc.m_OutputDram = outputBuffer;
     passDesc.m_Output     = outputBuffer;
-    result.m_Metric       = CalculateMetric(result.m_LegacyStats, passDesc, &result.m_DebugInfo);
+    result.m_Metric       = CalculateMetric(result.m_LegacyStats, passDesc, &result.m_PassDebugStat);
 
     return result;
 }
@@ -391,7 +392,7 @@ EstimatedPass EstimatePassGrownFrom(const OpGraph& opGraph,
 
     passDesc.m_Mce  = mceOp;
     passDesc.m_Ple  = pleOp;
-    result.m_Metric = CalculateMetric(result.m_LegacyStats, passDesc, &result.m_DebugInfo);
+    result.m_Metric = CalculateMetric(result.m_LegacyStats, passDesc, &result.m_PassDebugStat);
 
     return result;
 }

--- a/driver/support_library/src/Estimation.hpp
+++ b/driver/support_library/src/Estimation.hpp
@@ -1,5 +1,6 @@
 //
 // Copyright © 2020-2023 Arm Limited.
+// Copyright © 2024 Axis Communications AB.
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -22,6 +23,7 @@ struct EstimatedPass
     /// The estimated cycle count for this pass.
     double m_Metric;
     /// Additional information helpful for debugging the performance estimation, shown in dot files.
+    PassDebugStats m_PassDebugStat;
     std::string m_DebugInfo;
     /// The Ops included in this pass.
     std::vector<Op*> m_Ops;

--- a/driver/support_library/src/EstimationUtils.hpp
+++ b/driver/support_library/src/EstimationUtils.hpp
@@ -1,5 +1,6 @@
 //
 // Copyright © 2020-2023 Arm Limited.
+// Copyright © 2024 Axis Communications AB.
 // SPDX-License-Identifier: Apache-2.0
 //
 #pragma once
@@ -76,7 +77,8 @@ struct PassDesc
     Buffer* m_Output     = nullptr;    ///< Either an SRAM or DRAM buffer
 };
 
-double CalculateMetric(const PassStats& legacyPerfData, const PassDesc& passDesc, std::string* outDebugInfo = nullptr);
+double CalculateMetric(const PassStats& legacyPerfData, const PassDesc& passDesc, PassDebugStats* passStat = nullptr);
+void GenerateDebug(const PassDebugStats& passStat, std::string* outDebugInfo);
 
 }    //namespace support_library
 }    //namespace ethosn

--- a/driver/support_library/src/Visualisation.cpp
+++ b/driver/support_library/src/Visualisation.cpp
@@ -1,5 +1,6 @@
 //
 // Copyright © 2018-2023 Arm Limited.
+// Copyright © 2024 Axis Communications AB.
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -961,8 +962,19 @@ void SaveEstimatedOpGraphToDot(const OpGraph& graph,
 
         // Add a "dummy" node showing the metric and debug info for this pass
         std::stringstream perfDetails;
+        std::string outDebugInfo;
+
+        if (estimationDetails.m_Passes[passIdx].m_PassDebugStat.valid)
+        {
+            GenerateDebug(estimationDetails.m_Passes[passIdx].m_PassDebugStat, &outDebugInfo);
+        }
+        else
+        {
+            outDebugInfo = estimationDetails.m_Passes[passIdx].m_DebugInfo;
+        }
+
         perfDetails << "Metric = " << estimationDetails.m_Passes[passIdx].m_Metric << "\n\n";
-        perfDetails << estimationDetails.m_Passes[passIdx].m_DebugInfo << "\n\n";
+        perfDetails << outDebugInfo << "\n\n";
         PrintPassPerformanceData(perfDetails, ethosn::utils::Indent(0),
                                  estimationDetails.m_LegacyPerfData.m_Stream[passIdx]);
         DotAttributes perfAttr(passId + "_Perf", perfDetails.str(), "");


### PR DESCRIPTION
CalculateMetric() created string formatting of debug data. This function is called in the inner loop of the compilation of networks so this is very costly. The debug data is used elsewhere (and in many cases not at all). Change so we only store the debug-data in the inner loop and then do the string formatting where it is actually needed.

This saving trims off 20% compilation time on mobilenet and 10% on efficientnet.